### PR TITLE
Storage mocking and testing facilities.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,8 @@ version = "0.1.0"
 authors = ["Jonathan Reem <jonathan.reem@gmail.com>"]
 
 [dependencies]
-fuse = "*"
+fuse = "0.2"
+scoped_threadpool = "0.1"
+rand = "0.3"
+uuid = "0.1"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 //! Lazy, peer-to-peer immutable object store.
 
 extern crate fuse;
+extern crate scoped_threadpool;
+extern crate rand;
+extern crate uuid;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::io;
@@ -8,26 +11,38 @@ use std::io;
 pub mod fs;
 pub mod s3;
 pub mod p2p;
+pub mod mock;
 
 mod lru;
-mod mock;
 mod impls;
 
 pub struct File;
-pub struct Chunk;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct FileDescriptor;
+pub struct Chunk(String);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ChunkDescriptor;
+pub struct FileDescriptor(String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ChunkDescriptor {
+    file: FileDescriptor,
+    chunk: Chunk
+}
 
 #[derive(Debug)]
 pub struct Version(AtomicUsize);
 
 impl Version {
+    fn new(v: usize) -> Version { Version(AtomicUsize::new(v))}
     fn load(&self) -> usize { self.0.load(Ordering::SeqCst) }
     fn increment(&self) -> usize { self.0.fetch_add(1, Ordering::SeqCst) }
+}
+
+impl Clone for Version {
+    fn clone(&self) -> Self {
+        Version::new(self.load())
+    }
 }
 
 pub trait Cache: Sync {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,16 +1,52 @@
+use scoped_threadpool::Pool;
+
+use uuid::Uuid;
+
 use std::collections::HashMap;
 use std::sync::RwLock;
 use std::io::{self, Write};
 use std::mem;
 
-use {Storage, Cache, ChunkDescriptor, Version};
+use {Storage, Cache, ChunkDescriptor, Version, Chunk, FileDescriptor};
 
 pub struct MockStorage {
     inner: RwLock<InnerMockStorage>
 }
 
+#[derive(Default)]
 struct InnerMockStorage {
     storage: HashMap<ChunkDescriptor, HashMap<Option<usize>, Vec<u8>>>
+}
+
+impl MockStorage {
+    pub fn new() -> Self {
+        MockStorage {
+            inner: RwLock::new(InnerMockStorage::default())
+        }
+    }
+}
+
+impl Cache for MockStorage {
+    fn read(&self, chunk: &ChunkDescriptor, version: Option<Version>,
+            mut buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.read().unwrap().read(chunk, version, buf)
+    }
+}
+
+impl Storage for MockStorage {
+    fn create(&self, chunk: &ChunkDescriptor, version: Option<Version>,
+              data: &[u8]) -> io::Result<()> {
+        self.inner.write().unwrap().create(chunk, version, data)
+    }
+
+    fn promote(&self, chunk: &ChunkDescriptor) -> io::Result<()> {
+        self.inner.write().unwrap().promote(chunk)
+    }
+
+    fn delete(&self, chunk: &ChunkDescriptor,
+              version: Option<Version>) -> io::Result<()> {
+        self.inner.write().unwrap().delete(chunk, version)
+    }
 }
 
 impl InnerMockStorage {
@@ -18,9 +54,12 @@ impl InnerMockStorage {
             mut buf: &mut [u8]) -> io::Result<usize> {
         self.storage
             .get(chunk)
-            .and_then(|chunk_map| chunk_map.get(&version.map(|v| v.load())))
-            .ok_or_else(|| panic!()) // TODO: Make notfound
-            .and_then(|object| {
+            .and_then(|chunk_map| chunk_map.get(&version.as_ref().map(|v| v.load())))
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::NotFound,
+                               format!("No object for {:?}-{:?}",
+                                       chunk, version.clone()))
+            }).and_then(|object| {
                 // TODO: Maybe be more flexible here, or just
                 // always ensure this is the case.
                 assert_eq!(object.len(), buf.len());
@@ -71,26 +110,156 @@ impl InnerMockStorage {
     }
 }
 
-impl Cache for MockStorage {
-    fn read(&self, chunk: &ChunkDescriptor, version: Option<Version>,
-            mut buf: &mut [u8]) -> io::Result<usize> {
-        self.inner.read().unwrap().read(chunk, version, buf)
+pub struct StorageFuzzer<S> {
+    storage: S
+}
+
+fn gen_random_chunk(chunk_size: usize) -> Vec<u8> {
+    vec![::rand::random::<u8>(); chunk_size]
+}
+
+fn gen_random_objects(num_objects: usize,
+                      chunk_size: usize,
+                      num_versions: usize) -> HashMap<Chunk, Vec<Vec<u8>>> {
+    (0..num_objects).map(|_| {
+        (Chunk(Uuid::new_v4().to_string()),
+         vec![gen_random_chunk(chunk_size); num_versions])
+    }).collect::<HashMap<Chunk, Vec<Vec<u8>>>>()
+}
+
+impl<S: Storage> StorageFuzzer<S> {
+    /// Run all fuzz tests on the underlying Storage.
+    ///
+    /// The magnitude is used to determine the relative size of a
+    /// number of internal parameters. A low magnitude will mean a
+    /// faster, but less thorough test; a high magnitude will mean a
+    /// slower, but more thorough test.
+    ///
+    /// Discovering the correct magnitude to use with your storage
+    /// usually requires some experimentation.
+    pub fn run(&self, magnitude: usize) {
+        self.check_properties(magnitude);
+        self.check_against_mock(magnitude);
+    }
+
+    /// Ensure that the Storage has the precise properties expected of it by fs::Fs.
+    ///
+    /// Runs many large series of randomized actions meant to emulate a specific
+    /// pattern of actions taken by the Fs then verifying that the Storage behaves
+    /// in the expected way.
+    pub fn check_properties(&self, magnitude: usize) {
+        // We will create this many worker threads for controlling
+        // this many objects. Each object is only manipulated by one thread.
+        let num_objects = magnitude * 100;
+
+        // The size of each chunk.
+        let chunk_size = magnitude * 100;
+
+        // The number of versions for each chunk.
+        let num_versions = magnitude * 10;
+
+        // Map of (chunk_id => (version => object))
+        // (the version => object map is represented as a Vec)
+        let objects = gen_random_objects(num_objects, chunk_size,
+                                         num_versions);
+
+        // Use a thread pool to run the tests.
+        let mut pool = Pool::new(objects.len() as u32);
+
+        pool.scoped(|scope| {
+            let file = Uuid::new_v4().to_string();
+            for (chunk, versions) in objects {
+                let file = file.clone();
+
+                // The test that gets run for each object.
+                let check_object = move || {
+                    let chunk_descriptor = ChunkDescriptor {
+                        file: FileDescriptor(file.clone()),
+                        chunk: chunk.clone()
+                    };
+
+                    // Write all the versions of the chunk in order.
+                    for (version, data) in versions.iter().enumerate() {
+                        self.storage.create(&chunk_descriptor,
+                                            Some(Version::new(version)),
+                                            data).unwrap();
+                    }
+
+                    // Make sure that all the versions of the chunk can
+                    // be recovered.
+                    let mut buffer = vec![0; chunk_size];
+                    for (version, data) in versions.iter().enumerate() {
+                        self.storage.read(&chunk_descriptor,
+                                          Some(Version::new(version)),
+                                          &mut buffer).unwrap();
+                        assert_eq!(data, &buffer);
+                    }
+
+                    // Ensure that promotion will save the last version.
+                    self.storage.promote(&chunk_descriptor).unwrap();
+                    self.storage.read(&chunk_descriptor, None, &mut buffer).unwrap();
+                    assert_eq!(&buffer, versions.last().unwrap())
+                };
+
+                // TODO: This unsafe block can go away in a few weeks.
+                unsafe { scope.execute(check_object) };
+            }
+        });
+    }
+
+    /// Ensure that the underlying Storage behaves equivalently to MockStorage
+    /// by runnning a large series of randomly generated actions concurrently.
+    ///
+    /// This test will attempt to find simple consistency and concurrency
+    /// errors in the Storage implementation.
+    ///
+    /// See `run` for an explanation of the `magnitude` parameter.
+    pub fn check_against_mock(&self, magnitude: usize) {
+        // Generate a bunch of random objects
     }
 }
 
-impl Storage for MockStorage {
-    fn create(&self, chunk: &ChunkDescriptor, version: Option<Version>,
-              data: &[u8]) -> io::Result<()> {
-        self.inner.write().unwrap().create(chunk, version, data)
+#[cfg(test)]
+mod test {
+    use {Storage, Cache, ChunkDescriptor, FileDescriptor, Chunk};
+
+    use mock::{MockStorage, StorageFuzzer};
+
+    #[test]
+    fn fuzz_mock_storage() {
+        let storage = MockStorage::new();
+        let fuzzer = StorageFuzzer { storage: storage };
+        fuzzer.run(2);
     }
 
-    fn promote(&self, chunk: &ChunkDescriptor) -> io::Result<()> {
-        self.inner.write().unwrap().promote(chunk)
-    }
+    #[test]
+    fn test_mock_storage_create_read() {
+        let data = &[1, 2, 3, 4, 5, 6, 7, 8];
 
-    fn delete(&self, chunk: &ChunkDescriptor,
-              version: Option<Version>) -> io::Result<()> {
-        self.inner.write().unwrap().delete(chunk, version)
+        let storage = MockStorage::new();
+
+        let chunk = ChunkDescriptor {
+            file: FileDescriptor("f".into()),
+            chunk: Chunk(::rand::random::<usize>().to_string())
+        };
+        let mut buf = vec![0; data.len()];
+        storage.create(&chunk, None, data).unwrap();
+        storage.read(&chunk, None, &mut buf).unwrap();
+        assert_eq!(&buf, data);
+
+        let chunk = ChunkDescriptor {
+            file: FileDescriptor("b".into()),
+            chunk: Chunk(::rand::random::<usize>().to_string())
+        };
+        let mut buf = vec![0; data.len()];
+        storage.create(&chunk, None, &data[..5]).unwrap();
+        storage.read(&chunk, None, &mut buf[..5]).unwrap();
+        assert_eq!(&buf[..5], &data[..5]);
+
+        // Try to overwrite, ensure it doesn't work.
+        storage.create(&chunk, None, data).unwrap();
+        storage.read(&chunk, None, &mut buf[..5]).unwrap();
+        assert_eq!(&buf, &[1, 2, 3, 4, 5, 0, 0, 0]);
     }
 }
 


### PR DESCRIPTION
StorageFuzzer is a generic test runner which can attempt to find bugs
in Storage implementations. It's recommended to use it in addition to custom
tests whenever implementing new Storages.
